### PR TITLE
feat: add support for custom config directory via env

### DIFF
--- a/aptkeeper
+++ b/aptkeeper
@@ -8,7 +8,7 @@ require 'tempfile'
 
 class AptKeeper
   HOME = Dir.home(Etc.getlogin) # Get user's home dir even if using sudo
-  CONFDIR = Pathname.new(HOME).join('.config', 'aptkeeper')
+  CONFDIR = Pathname.new(ENV["APT_KEEPER_DIR"] || File.join(HOME, '.config', 'aptkeeper'))
   EXTENDED_STATES = Pathname.new('/var/lib/apt/extended_states')
   DEBFOSTER = Pathname.new('/var/lib/debfoster/keepers')
 

--- a/aptkeeper
+++ b/aptkeeper
@@ -8,7 +8,7 @@ require 'tempfile'
 
 class AptKeeper
   HOME = Dir.home(Etc.getlogin) # Get user's home dir even if using sudo
-  CONFDIR = Pathname.new(ENV["APT_KEEPER_DIR"] || File.join(HOME, '.config', 'aptkeeper'))
+  CONFDIR = Pathname.new(ENV["APTKEEPER_DIR"] || File.join(HOME, '.config', 'aptkeeper'))
   EXTENDED_STATES = Pathname.new('/var/lib/apt/extended_states')
   DEBFOSTER = Pathname.new('/var/lib/debfoster/keepers')
 


### PR DESCRIPTION
Add option to read config from a custom directory defined by the
environment variable APT_KEEPER_DIR instead of fixed ~/.config/aptkeeper
